### PR TITLE
Fix errors due to misplaced `read_data.py` and NionSwift 16.2

### DIFF
--- a/nionswift_plugin/EELS_spec/eels_spec_inst.py
+++ b/nionswift_plugin/EELS_spec/eels_spec_inst.py
@@ -7,9 +7,10 @@ from nion.utils import Event
 from nion.utils import Observable
 from nion.instrumentation.HardwareSource import Instrument
 
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 set_file = read_data.FileManager('global_settings')
+print(set_file.settings.keys())
 SERIAL_PORT = set_file.settings["EELS"]["COM"]
 LAST_HT = set_file.settings["global_settings"]["last_HT"]
 

--- a/nionswift_plugin/IVG/camera/VGCameraYves.py
+++ b/nionswift_plugin/IVG/camera/VGCameraYves.py
@@ -21,7 +21,7 @@ from nion.instrumentation import camera_base
 from nionswift_plugin.IVG.tp3 import tp3func
 
 from nionswift_plugin.IVG import ivg_inst
-from ...aux_files.config import read_data
+from ...aux_files import read_data
 
 _ = gettext.gettext
 
@@ -185,28 +185,28 @@ class CameraDevice(camera_base.CameraDevice):
             if self.frame_parameter_changed_event is not None:
                 self.frame_parameter_changed_event.fire("exposure_ms")
 
-        if "acquisition_mode" in frame_parameters:
+        if hasattr(frame_parameters, "acquisition_mode"):
             if self.frame_parameter_changed_event is not None:
                 self.frame_parameter_changed_event.fire("acquisition_mode")
 
-        if "soft_binning" in frame_parameters:
+        if hasattr(frame_parameters, "soft_binning"):
             self.__hardware_settings.soft_binning = frame_parameters.soft_binning
             if self.__hardware_settings.acquisition_mode != frame_parameters.acquisition_mode:
                 self.__hardware_settings.acquisition_mode = frame_parameters.acquisition_mode
             print(f"***CAMERA***: acquisition mode[camera]: {self.__hardware_settings.acquisition_mode}")
             self.__hardware_settings.spectra_count = frame_parameters.spectra_count
 
-        if "port" in frame_parameters:
+        if hasattr(frame_parameters, "port"):
             if self.__hardware_settings.port != frame_parameters.port:
                 self.__hardware_settings.port = frame_parameters.port
                 self.camera.setCurrentPort(frame_parameters.port)
 
-        if "speed" in frame_parameters:
+        if hasattr(frame_parameters, "speed"):
             if self.__hardware_settings.speed != frame_parameters.speed:
                 self.__hardware_settings.speed = frame_parameters.speed
                 self.camera.setSpeed(self.__hardware_settings.port, frame_parameters.speed)
 
-        if "area" in frame_parameters:
+        if hasattr(frame_parameters, "area"):
             if any(i != j for i, j in zip(self.__hardware_settings.area, frame_parameters.area)):
                 # if change area, put back binning to 1,1 temporarily in order to avoid conflicts, binnig will then be setup later
                 self.__hardware_settings.h_binning = 1
@@ -215,44 +215,44 @@ class CameraDevice(camera_base.CameraDevice):
                 self.__hardware_settings.area = frame_parameters.area
                 self.camera.setArea(self.__hardware_settings.area)
 
-        if ("h_binning" in frame_parameters) and ("v_binning" in frame_parameters):
+        if (hasattr(frame_parameters, "h_binning") and hasattr(frame_parameters, "v_binning")):
             if (self.__hardware_settings.h_binning != frame_parameters.h_binning) \
                     or (self.__hardware_settings.v_binning != frame_parameters.v_binning):
                 self.camera.setBinning(frame_parameters.h_binning, frame_parameters.v_binning)
                 self.__hardware_settings.h_binning, self.__hardware_settings.v_binning = self.camera.getBinning()
 
-        if "gain" in frame_parameters:
+        if hasattr(frame_parameters, "gain"):
             if self.__hardware_settings.gain != frame_parameters.gain:
                 self.__hardware_settings.gain = frame_parameters.gain
                 self.camera.setGain(self.__hardware_settings.gain)
 
-        if "multiplication" in frame_parameters:
+        if hasattr(frame_parameters, "multiplication"):
             if self.__hardware_settings.multiplication != frame_parameters.multiplication:
                 self.__hardware_settings.multiplication = frame_parameters.multiplication
                 self.camera.setMultiplication(self.__hardware_settings.multiplication)
 
-        if "spectra_count" in frame_parameters:
+        if hasattr(frame_parameters, "spectra_count"):
             self.__hardware_settings.spectra_count = frame_parameters.spectra_count
             self.camera.setAccumulationNumber(self.__hardware_settings.spectra_count)
-        if "video_threshold" in frame_parameters:
+        if hasattr(frame_parameters, "video_threshold"):
             self.__hardware_settings.video_threshold = frame_parameters.video_threshold
             self.camera.setVideoThreshold(self.__hardware_settings.video_threshold)
-        if "fan_enabled" in frame_parameters:
+        if hasattr(frame_parameters, "fan_enabled"):
             self.__hardware_settings.fan_enabled = frame_parameters.fan_enabled
             self.camera.setFan(self.__hardware_settings.fan_enabled)
 
-        if "processing" in frame_parameters:
+        if hasattr(frame_parameters, "processing"):
             self.__hardware_settings.processing = frame_parameters.processing
 
-        if self.isTimepix and "timeDelay" in frame_parameters:
+        if self.isTimepix and hasattr(frame_parameters, "timeDelay"):
             self.__hardware_settings.timeDelay = frame_parameters.timeDelay
             self.camera.setDelayTime(frame_parameters.timeDelay)
 
-        if self.isTimepix and "timeWidth" in frame_parameters:
+        if self.isTimepix and hasattr(frame_parameters, "timeWidth"):
             self.__hardware_settings.timeWidth = frame_parameters.timeWidth
             self.camera.setWidthTime(frame_parameters.timeWidth)
 
-        if self.isTimepix and "tp3mode" in frame_parameters:
+        if self.isTimepix and hasattr(frame_parameters, "tp3mode"):
             self.__hardware_settings.tp3mode = frame_parameters.tp3mode
             self.camera.setTp3Mode(frame_parameters.tp3mode)
 

--- a/nionswift_plugin/IVG/ivg_inst.py
+++ b/nionswift_plugin/IVG/ivg_inst.py
@@ -10,7 +10,7 @@ from nion.swift.model import HardwareSource
 from nion.instrumentation import stem_controller
 from nion.utils import Geometry
 
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 sender_email = "vg.lumiere@gmail.com"
 receiver_email = "yvesauad@gmail.com"

--- a/nionswift_plugin/OptSpec/__init__.py
+++ b/nionswift_plugin/OptSpec/__init__.py
@@ -1,7 +1,7 @@
 from nion.instrumentation import HardwareSource
 
 from . import optspec_inst, optspec_panel
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 set_file = read_data.FileManager('global_settings')
 MANUFACTURER = set_file.settings["spectrometer"]["WHICH"]

--- a/nionswift_plugin/OptSpec/optspec_inst.py
+++ b/nionswift_plugin/OptSpec/optspec_inst.py
@@ -7,7 +7,7 @@ import logging
 from nion.utils import Event
 from nion.utils import Observable
 from nion.swift.model import HardwareSource
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 
 class OptSpecDevice(Observable.Observable):

--- a/nionswift_plugin/OptSpec/spec.py
+++ b/nionswift_plugin/OptSpec/spec.py
@@ -1,6 +1,6 @@
 import serial
 import logging
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 __author__ = "Yves Auad"
 

--- a/nionswift_plugin/diaf/diaf_inst.py
+++ b/nionswift_plugin/diaf/diaf_inst.py
@@ -3,7 +3,7 @@ import logging
 
 from nion.utils import Event
 from nion.utils import Observable
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 set_file = read_data.FileManager('global_settings')
 SERIAL_PORT = set_file.settings["diaf"]["COM"]

--- a/nionswift_plugin/lenses/probe_inst.py
+++ b/nionswift_plugin/lenses/probe_inst.py
@@ -5,7 +5,7 @@ import time
 from nion.utils import Event
 from nion.utils import Observable
 from nion.swift.model import HardwareSource
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 set_file = read_data.FileManager('global_settings')
 SERIAL_PORT = set_file.settings["lenses"]["COM"]

--- a/nionswift_plugin/stage/stage_inst.py
+++ b/nionswift_plugin/stage/stage_inst.py
@@ -8,7 +8,7 @@ import shutil
 
 from nion.utils import Event
 from nion.utils import Observable
-from ..aux_files.config import read_data
+from ..aux_files import read_data
 
 set_file = read_data.FileManager('global_settings')
 DEBUG = set_file.settings["stage"]["DEBUG"]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,43 @@
+from setuptools import setup
+
+setup(
+    name="OrsayLille",
+    version="LumiereBranch",
+    author="Yves Auad",
+    description="Set of tools to run VG Cold Microscope in Nionswift",
+    url="https://github.com/yvesauad/swift_lumiere",
+    packages=[
+        "nionswift_plugin.EELS_spec",
+        "nionswift_plugin.IVG",
+        "nionswift_plugin.IVG.virtual_instruments",
+        "nionswift_plugin.IVG.tp3",
+        "nionswift_plugin.IVG.camera",
+    ],
+    python_requires=">=3.8.5",
+    data_files=[
+        (
+            "nionswift_plugin/aux_files/config",
+            [
+                "nionswift_plugin/aux_files/config/Lille/global_settings.json",
+                "nionswift_plugin/aux_files/config/Lille/eels_settings.json",
+                "nionswift_plugin/aux_files/config/Lille/Orsay_cameras_list.json",
+            ],
+        ),
+        (
+            "nionswift_plugin/aux_files/DLLs",
+            [
+                "nionswift_plugin/aux_files/DLLs/Cameras.dll",
+                "nionswift_plugin/aux_files/DLLs/atmcd64d.dll",
+                "nionswift_plugin/aux_files/DLLs/Scan.dll",
+                "nionswift_plugin/aux_files/DLLs/udk3-1.4-x86_64.dll",
+                "nionswift_plugin/aux_files/DLLs/udk3mod-1.4-winusb-x86_64.dll",
+                "nionswift_plugin/aux_files/DLLs/STEMSerial.dll",
+                "nionswift_plugin/aux_files/DLLs/Stepper.dll",
+                "nionswift_plugin/aux_files/DLLs/delib64.dll",
+                "nionswift_plugin/aux_files/DLLs/SpectroCL.dll",
+                "nionswift_plugin/aux_files/DLLs/AttoClient.dll",
+            ],
+        ),
+    ],
+    install_requires=["pyserial>=3.5", "requests>=2.25.1", "nionswift-usim>=0.3.0"],
+)


### PR DESCRIPTION
In my installation, using Nion Swift 16.2, I need the fixes in this PR to run the plugin.

In particular:

* The path of the `read_data.py` file was wrong
* In NS 16.2, ``frame_parameters`` is not a ``dict``, so things like ``if "acquisition_mode" in frame_parameters:`` don't work.